### PR TITLE
Fix printing message to variable when substituting

### DIFF
--- a/zinsults.plugin.zsh
+++ b/zinsults.plugin.zsh
@@ -36,7 +36,11 @@ function command_not_found_handler {
 	fi
 	if (($#msgs>0));then
 		RANDOM=$(od -vAn -N4 -tu < /dev/urandom)
-		builtin print -P -f 'zsh: %s\n' "$msgs[RANDOM % $#msgs + 1]"
+		if [[ -w $TTY ]]; then
+			builtin print -P -f 'zsh: %s\n' "$msgs[RANDOM % $#msgs + 1]" >$TTY
+		else
+			builtin print -P -f 'zsh: %s\n' "$msgs[RANDOM % $#msgs + 1]"
+		fi
 		unset msgs
 	fi
 	__zinsult_try_find_command "$@"

--- a/zinsults.plugin.zsh
+++ b/zinsults.plugin.zsh
@@ -26,6 +26,10 @@ if (( ! ${+zinsults_load} )); then
 fi
 
 function command_not_found_handler {
+	if [[ ! -t 1 ]]; then
+		# Return if stdout is a pipe, not tty
+		return
+	fi
 	local -a msgs
 	local idx
 	setopt localoptions noksharrays
@@ -36,11 +40,7 @@ function command_not_found_handler {
 	fi
 	if (($#msgs>0));then
 		RANDOM=$(od -vAn -N4 -tu < /dev/urandom)
-		if [[ -w $TTY ]]; then
-			builtin print -P -f 'zsh: %s\n' "$msgs[RANDOM % $#msgs + 1]" >$TTY
-		else
-			builtin print -P -f 'zsh: %s\n' "$msgs[RANDOM % $#msgs + 1]"
-		fi
+		builtin print -P -f 'zsh: %s\n' "$msgs[RANDOM % $#msgs + 1]"
 		unset msgs
 	fi
 	__zinsult_try_find_command "$@"


### PR DESCRIPTION
Bug:
When doing v=$(some-nonexisting-command), message will be written to $v instead of printing to terminal.

In example this breaks completion of 'man' on Termux due to non-existent manpath command

Fix: Write messages directly to terminal instead of stdout when possible